### PR TITLE
chore(README.md): adding `bolt start` command into the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ yarn global add bolt
 | `bolt [unknown command]`                | (Defaults to `bolt run [unknown command]`)                                |✅|
 | `bolt help`                             | View Bolt's help content                                                  |❌|
 | `bolt help [command]`                   | View Bolt's help content for a single command                             |❌|
+| `bolt start`                            | Start the server for a specific project                                   |✅|
 | `bolt init`                             | Create a new Bolt package in the current directory                        |✅|
 | └ `bolt init --yes`                     | Skip the prompts and use defaults                                         |✅|
 | `bolt install`                          | Install all the dependencies for a project                                |✅|


### PR DESCRIPTION
## This is a

[x] Document update


## About this change

Adding `bolt start` command into the `README.md` list. So that everyone can check the command without look the code implementation